### PR TITLE
Remove duplicated code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -299,7 +299,7 @@ notes=TODO
 
 # This flag controls whether inconsistent-quotes generates a warning when the
 # character used as a quote delimiter is used inconsistently within a module.
-check-quote-consistency=yes
+# check-quote-consistency=yes
 
 
 [VARIABLES]


### PR DESCRIPTION
This PR removes duplicated code for the special cases `"won't"` and `"can't"`.

These auxiliary verbs are split into `"wo"` (AUX) and `"n't"` (neg), and `"ca"` (AUX) / `"n't"` (neg), respectively. If we simply removed the negation as with other negated auxiliaries (e.g., `"cannot"` → `"can"` (AUX) / `"not"` (neg), we remove `"not"` and keep `"can"`), we would end up with `"wo"` and `"ca"`, which are not correct words. Therefore, we need to take extra steps to replace these words by `"will"` and `"can"`, respectively.